### PR TITLE
Fix link typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > A curated list of Github's awesomeness
 
-Think Github is awesome? Contribute something to this list! It's easy, just have a look at the [contribution guidelines](contributing.md).
+Think Github is awesome? Contribute something to this list! It's easy, just have a look at the [contribution guidelines](CONTRIBUTING.md).
 
 The awesomeness is currently organized into just few different buckets: 
 


### PR DESCRIPTION
The file names are case-sensitive, it seems.