### PR TITLE
Ghizmo, a command line for GitHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ great software, presented by GitHub. October 1 & 2, 2015, SF.
 - [Redliner](https://github.com/benbalter/redliner) - A tool for facilitating the redlining of documents with the GitHub uninitiated. 
 - [Gatekeeper](https://github.com/prose/gatekeeper)Enables client-side applications to dance OAuth with GitHub.
 - [github-secret-keeper](https://github.com/HenrikJoreteg/github-secret-keeper) - Microservice to enable GitHub login for multiple server-less applications.
-
+- [Ghizmo](https://github.com/jlevy/ghizmo) - A command line for GitHub, allowing access to all APIs.


### PR DESCRIPTION
Thanks for making this list.

Shameless promotion of a recent hack of my own that may be relevant: [Ghizmo](https://github.com/jlevy/ghizmo).
It's basically a command line for much of the GitHub functionality you'd normally have with the web interface.

Feel free to consider it for inclusion if it looks useful. Would also be glad for feedback/contributions on the tool.