### PR TITLE
Add `hub` a CLI created by the github team

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ great software, presented by GitHub. October 1 & 2, 2015, SF.
 - [Gatekeeper](https://github.com/prose/gatekeeper) - Enables client-side applications to dance OAuth with GitHub.
 - [github-secret-keeper](https://github.com/HenrikJoreteg/github-secret-keeper) - Microservice to enable GitHub login for multiple server-less applications.
 - [Ghizmo](https://github.com/jlevy/ghizmo) - A command line for GitHub, allowing access to all APIs.
+- [Hub](https://github.com/github/hub) - A command line tool that wraps git in order to extend it with extra features and commands that make working with GitHub easier


### PR DESCRIPTION
It wraps `git` and has a few really great additions, one of which I use really frequently: [the ability to convert an existing issue into a PR](http://opensoul.org/2012/11/09/convert-a-github-issue-into-a-pull-request/)