### PR TITLE
Added Zappr to "Tips, tricks..." section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ great software, presented by GitHub. October 1 & 2, 2015, SF.
 - [HubPress](https://github.com/HubPress/hubpress.io) - A web application to build your Blog on GitHub
 - [TinyPress](https://tinypress.co/) - TinyPress is the easiest way to publish a blog on GitHub.
 - [Issue and Pull Request Template Generator](https://www.talater.com/open-source-templates/) - Generate templates customized to your project, with the help of Cthulhu and Lewis Carroll
+- [Zappr](https://github.com/zalando/zappr) - A free/open-source GitHub integration that removes bottlenecks around pull request approval and helps dev teams to painlessly abide by compliance requirements.
 
 ## Novel uses of GitHub
 


### PR DESCRIPTION
Added it at the bottom. Zappr can be pretty useful to devs who want to do code review and PR approval *inside* of GitHub. It's also 100% free to use.